### PR TITLE
fix(build): Move deb/rpm packaging from build to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,36 +107,8 @@ jobs:
           # Compress tar file
           gzip alpinezen-wallpaper-${{ matrix.os }}-${{ matrix.arch }}.tar
 
-      - name: Create Linux deb
-        uses: burningalchemist/action-gh-nfpm@v1
-        if: matrix.os == 'linux'
-        with:
-          packager: deb
-          config: assets/linux/nfpm.yaml
-          target: dist/alpinezen-wallpaper-${{ matrix.os }}-${{ matrix.arch }}.deb
-
-      - name: Create Linux rpm
-        uses: burningalchemist/action-gh-nfpm@v1
-        if: matrix.os == 'linux'
-        with:
-          packager: rpm
-          config: assets/linux/nfpm.yaml
-          target: dist/alpinezen-wallpaper-${{ matrix.os }}-${{ matrix.arch }}.rpm
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: alpinezen-wallpaper-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
           path: dist/alpinezen-wallpaper-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-
-      - name: Upload rpm
-        uses: actions/upload-artifact@v4
-        with:
-          name: alpinezen-wallpaper-${{ matrix.os }}-${{ matrix.arch }}.rpm
-          path: dist/alpinezen-wallpaper-${{ matrix.os }}-${{ matrix.arch }}.rpm
-
-      - name: Upload deb
-        uses: actions/upload-artifact@v4
-        with:
-          name: alpinezen-wallpaper-${{ matrix.os }}-${{ matrix.arch }}.deb
-          path: dist/alpinezen-wallpaper-${{ matrix.os }}-${{ matrix.arch }}.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux]
+        arch: [arm64, amd64]
+      fail-fast: false
 
     steps:
       - name: Checkout repository
@@ -45,6 +50,24 @@ jobs:
         with:
           path: .
 
+      - name: Create Linux deb
+        uses: burningalchemist/action-gh-nfpm@v1
+        if: matrix.os == 'linux'
+        with:
+          packager: deb
+          config: assets/linux/nfpm.yaml
+          target: alpinezen-wallpaper-${{ matrix.os }}-${{ matrix.arch }}.deb
+          version: ${{ env.VERSION }}
+
+      - name: Create Linux rpm
+        uses: burningalchemist/action-gh-nfpm@v1
+        if: matrix.os == 'linux'
+        with:
+          packager: rpm
+          config: assets/linux/nfpm.yaml
+          target: alpinezen-wallpaper-${{ matrix.os }}-${{ matrix.arch }}.rpm
+          version: ${{ env.VERSION }}
+
       - name: Rename artifacts with version and build number
         run: |
           find . -type f \( -name "*.tar.gz" -o -name "*.dmg" \) | while read file; do
@@ -68,4 +91,4 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.token }}
-          artifacts: "**/*.tar.gz,**/*.dmg"
+          artifacts: "**/*.tar.gz,**/*.dmg,**/*.deb,**/*.rpm"


### PR DESCRIPTION
- Remove deb/rpm creation steps from build.yml workflow
- Add matrix configuration for Linux builds in release.yml
- Implement deb/rpm package creation in release workflow with versioning
- Update GitHub release artifact pattern to include deb/rpm packages
